### PR TITLE
修复蒸汽网络清空bug

### DIFF
--- a/src/main/java/com/science/gtnl/utils/world/steam/GlobalSteamWorldSavedData.java
+++ b/src/main/java/com/science/gtnl/utils/world/steam/GlobalSteamWorldSavedData.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 
@@ -60,7 +61,7 @@ public class GlobalSteamWorldSavedData extends WorldSavedData {
                 ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
 
                 Object data = objectInputStream.readObject();
-                Map<Object, BigInteger> hashData = (Map<Object, BigInteger>) data;
+                HashMap<Object, BigInteger> hashData = (HashMap<Object, BigInteger>) data;
 
                 for (Map.Entry<Object, BigInteger> entry : hashData.entrySet()) {
                     try {
@@ -90,7 +91,7 @@ public class GlobalSteamWorldSavedData extends WorldSavedData {
                 ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
 
                 Object data = objectInputStream.readObject();
-                Map<String, String> oldTeams = (Map<String, String>) data;
+                HashMap<String, String> oldTeams = (HashMap<String, String>) data;
 
                 for (Map.Entry<String, String> entry : oldTeams.entrySet()) {
                     try {

--- a/src/main/java/com/science/gtnl/utils/world/steam/GlobalSteamWorldSavedData.java
+++ b/src/main/java/com/science/gtnl/utils/world/steam/GlobalSteamWorldSavedData.java
@@ -1,127 +1,200 @@
 package com.science.gtnl.utils.world.steam;
 
-import static com.science.gtnl.utils.world.steam.SteamWirelessNetworkManager.GLOBAL_STEAM;
-
+import com.science.gtnl.ScienceNotLeisure;
+import gregtech.common.misc.spaceprojects.SpaceProjectManager;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigInteger;
-import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
-
+import java.util.Map.Entry;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSavedData;
 import net.minecraft.world.storage.MapStorage;
 
-import com.science.gtnl.ScienceNotLeisure;
-
-import gregtech.common.misc.spaceprojects.SpaceProjectManager;
-
 public class GlobalSteamWorldSavedData extends WorldSavedData {
+   public static GlobalSteamWorldSavedData INSTANCE;
+   public static final String DATA_NAME = "GregTech_WirelessSteamWorldSavedData";
+   public static final String GLOBAL_STEAM_NBT_TAG = "GregTech_GlobalSteam_MapNBTTag";
+   public static final String GLOBAL_STEAM_TEAM_NBT_TAG = "GregTech_GlobalSteamTeam_MapNBTTag";
 
-    public static GlobalSteamWorldSavedData INSTANCE;
+   public static void loadInstance(World world) {
+      SteamWirelessNetworkManager.GLOBAL_STEAM.clear();
+      MapStorage storage = world.field_72988_C;
+      INSTANCE = (GlobalSteamWorldSavedData)storage.func_75742_a(GlobalSteamWorldSavedData.class, "GregTech_WirelessSteamWorldSavedData");
+      if (INSTANCE == null) {
+         INSTANCE = new GlobalSteamWorldSavedData();
+         storage.func_75745_a("GregTech_WirelessSteamWorldSavedData", INSTANCE);
+      }
 
-    public static final String DATA_NAME = "GregTech_WirelessSteamWorldSavedData";
+      INSTANCE.func_76185_a();
+   }
 
-    public static final String GLOBAL_STEAM_NBT_TAG = "GregTech_GlobalSteam_MapNBTTag";
-    public static final String GLOBAL_STEAM_TEAM_NBT_TAG = "GregTech_GlobalSteamTeam_MapNBTTag";
+   public GlobalSteamWorldSavedData() {
+      super("GregTech_WirelessSteamWorldSavedData");
+   }
 
-    public static void loadInstance(World world) {
-        GLOBAL_STEAM.clear();
+   public GlobalSteamWorldSavedData(String name) {
+      super(name);
+   }
 
-        MapStorage storage = world.mapStorage;
-        INSTANCE = (GlobalSteamWorldSavedData) storage.loadData(GlobalSteamWorldSavedData.class, DATA_NAME);
-        if (INSTANCE == null) {
-            INSTANCE = new GlobalSteamWorldSavedData();
-            storage.setData(DATA_NAME, INSTANCE);
-        }
-        INSTANCE.markDirty();
-    }
+   public void func_76184_a(NBTTagCompound nbtTagCompound) {
+      byte[] ba;
+      ByteArrayInputStream byteArrayInputStream;
+      ObjectInputStream objectInputStream;
+      Object data;
+      Map oldTeams;
+      Iterator var7;
+      Entry entry;
+      try {
+         ba = nbtTagCompound.func_74770_j("GregTech_GlobalSteam_MapNBTTag");
+         if (ba.length == 0) {
+            return;
+         }
 
-    public GlobalSteamWorldSavedData() {
-        super(DATA_NAME);
-    }
+         byteArrayInputStream = new ByteArrayInputStream(ba);
 
-    public GlobalSteamWorldSavedData(String name) {
-        super(name);
-    }
+         try {
+            objectInputStream = new ObjectInputStream(byteArrayInputStream);
 
-    @Override
-    @SuppressWarnings("unchecked")
-    public void readFromNBT(NBTTagCompound nbtTagCompound) {
-        try {
-            byte[] ba = nbtTagCompound.getByteArray(GLOBAL_STEAM_NBT_TAG);
-            if (ba.length == 0) return;
+            try {
+               data = objectInputStream.readObject();
+               oldTeams = (Map)data;
+               var7 = oldTeams.entrySet().iterator();
 
-            try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(ba);
-                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+               while(var7.hasNext()) {
+                  entry = (Entry)var7.next();
 
-                Object data = objectInputStream.readObject();
-                HashMap<Object, BigInteger> hashData = (HashMap<Object, BigInteger>) data;
+                  try {
+                     SteamWirelessNetworkManager.GLOBAL_STEAM.put(UUID.fromString(entry.getKey().toString()), (BigInteger)entry.getValue());
+                  } catch (RuntimeException var15) {
+                     ScienceNotLeisure.LOG.warn("[GlobalSteamWorldSavedData] Skipping invalid UUID key in GlobalSteam: {}", new Object[]{entry.getKey()});
+                  }
+               }
+            } catch (Throwable var19) {
+               try {
+                  objectInputStream.close();
+               } catch (Throwable var14) {
+                  var19.addSuppressed(var14);
+               }
 
-                for (Map.Entry<Object, BigInteger> entry : hashData.entrySet()) {
-                    try {
-                        GLOBAL_STEAM.put(
-                            UUID.fromString(
-                                entry.getKey()
-                                    .toString()),
-                            entry.getValue());
-                    } catch (RuntimeException ignored) {
-                        ScienceNotLeisure.LOG.warn(
-                            "[GlobalSteamWorldSavedData] Skipping invalid UUID key in GlobalSteam: {}",
-                            entry.getKey());
-                    }
-                }
+               throw var19;
             }
-        } catch (IOException | ClassNotFoundException exception) {
-            ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} LOAD FAILED", GLOBAL_STEAM_NBT_TAG, exception);
-        }
 
-        try {
-            if (!nbtTagCompound.hasKey(GLOBAL_STEAM_TEAM_NBT_TAG)) return;
-
-            byte[] ba = nbtTagCompound.getByteArray(GLOBAL_STEAM_TEAM_NBT_TAG);
-            if (ba.length == 0) return;
-
-            try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(ba);
-                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
-
-                Object data = objectInputStream.readObject();
-                HashMap<String, String> oldTeams = (HashMap<String, String>) data;
-
-                for (Map.Entry<String, String> entry : oldTeams.entrySet()) {
-                    try {
-                        SpaceProjectManager
-                            .putInTeam(UUID.fromString(entry.getKey()), UUID.fromString(entry.getValue()));
-                    } catch (RuntimeException ignored) {
-                        ScienceNotLeisure.LOG.warn(
-                            "[GlobalSteamWorldSavedData] Skipping invalid UUID in team entry: {}",
-                            entry.getKey());
-                    }
-                }
+            objectInputStream.close();
+         } catch (Throwable var20) {
+            try {
+               byteArrayInputStream.close();
+            } catch (Throwable var13) {
+               var20.addSuppressed(var13);
             }
-        } catch (IOException | ClassNotFoundException exception) {
-            ScienceNotLeisure.LOG
-                .error("[GlobalSteamWorldSavedData] {} LOAD FAILED", GLOBAL_STEAM_TEAM_NBT_TAG, exception);
-        }
-    }
 
-    @Override
-    public void writeToNBT(NBTTagCompound nbtTagCompound) {
-        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
+            throw var20;
+         }
 
-            objectOutputStream.writeObject(GLOBAL_STEAM);
-            objectOutputStream.flush();
+         byteArrayInputStream.close();
+      } catch (ClassNotFoundException | IOException var21) {
+         ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} LOAD FAILED", new Object[]{"GregTech_GlobalSteam_MapNBTTag", var21});
+      }
 
-            nbtTagCompound.setByteArray(GLOBAL_STEAM_NBT_TAG, byteArrayOutputStream.toByteArray());
+      try {
+         if (!nbtTagCompound.func_74764_b("GregTech_GlobalSteamTeam_MapNBTTag")) {
+            return;
+         }
 
-        } catch (IOException exception) {
-            ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} SAVE FAILED", GLOBAL_STEAM_NBT_TAG, exception);
-        }
-    }
+         ba = nbtTagCompound.func_74770_j("GregTech_GlobalSteamTeam_MapNBTTag");
+         if (ba.length == 0) {
+            return;
+         }
+
+         byteArrayInputStream = new ByteArrayInputStream(ba);
+
+         try {
+            objectInputStream = new ObjectInputStream(byteArrayInputStream);
+
+            try {
+               data = objectInputStream.readObject();
+               oldTeams = (Map)data;
+               var7 = oldTeams.entrySet().iterator();
+
+               while(var7.hasNext()) {
+                  entry = (Entry)var7.next();
+
+                  try {
+                     SpaceProjectManager.putInTeam(UUID.fromString((String)entry.getKey()), UUID.fromString((String)entry.getValue()));
+                  } catch (RuntimeException var12) {
+                     ScienceNotLeisure.LOG.warn("[GlobalSteamWorldSavedData] Skipping invalid UUID in team entry: {}", new Object[]{entry.getKey()});
+                  }
+               }
+            } catch (Throwable var16) {
+               try {
+                  objectInputStream.close();
+               } catch (Throwable var11) {
+                  var16.addSuppressed(var11);
+               }
+
+               throw var16;
+            }
+
+            objectInputStream.close();
+         } catch (Throwable var17) {
+            try {
+               byteArrayInputStream.close();
+            } catch (Throwable var10) {
+               var17.addSuppressed(var10);
+            }
+
+            throw var17;
+         }
+
+         byteArrayInputStream.close();
+      } catch (ClassNotFoundException | IOException var18) {
+         ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} LOAD FAILED", new Object[]{"GregTech_GlobalSteamTeam_MapNBTTag", var18});
+      }
+
+   }
+
+   public void func_76187_b(NBTTagCompound nbtTagCompound) {
+      try {
+         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+         try {
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
+
+            try {
+               objectOutputStream.writeObject(SteamWirelessNetworkManager.GLOBAL_STEAM);
+               objectOutputStream.flush();
+               nbtTagCompound.func_74773_a("GregTech_GlobalSteam_MapNBTTag", byteArrayOutputStream.toByteArray());
+            } catch (Throwable var8) {
+               try {
+                  objectOutputStream.close();
+               } catch (Throwable var7) {
+                  var8.addSuppressed(var7);
+               }
+
+               throw var8;
+            }
+
+            objectOutputStream.close();
+         } catch (Throwable var9) {
+            try {
+               byteArrayOutputStream.close();
+            } catch (Throwable var6) {
+               var9.addSuppressed(var6);
+            }
+
+            throw var9;
+         }
+
+         byteArrayOutputStream.close();
+      } catch (IOException var10) {
+         ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} SAVE FAILED", new Object[]{"GregTech_GlobalSteam_MapNBTTag", var10});
+      }
+
+   }
 }

--- a/src/main/java/com/science/gtnl/utils/world/steam/GlobalSteamWorldSavedData.java
+++ b/src/main/java/com/science/gtnl/utils/world/steam/GlobalSteamWorldSavedData.java
@@ -1,200 +1,126 @@
 package com.science.gtnl.utils.world.steam;
 
-import com.science.gtnl.ScienceNotLeisure;
-import gregtech.common.misc.spaceprojects.SpaceProjectManager;
+import static com.science.gtnl.utils.world.steam.SteamWirelessNetworkManager.GLOBAL_STEAM;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.math.BigInteger;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.UUID;
-import java.util.Map.Entry;
+
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 import net.minecraft.world.WorldSavedData;
 import net.minecraft.world.storage.MapStorage;
 
+import com.science.gtnl.ScienceNotLeisure;
+
+import gregtech.common.misc.spaceprojects.SpaceProjectManager;
+
 public class GlobalSteamWorldSavedData extends WorldSavedData {
-   public static GlobalSteamWorldSavedData INSTANCE;
-   public static final String DATA_NAME = "GregTech_WirelessSteamWorldSavedData";
-   public static final String GLOBAL_STEAM_NBT_TAG = "GregTech_GlobalSteam_MapNBTTag";
-   public static final String GLOBAL_STEAM_TEAM_NBT_TAG = "GregTech_GlobalSteamTeam_MapNBTTag";
 
-   public static void loadInstance(World world) {
-      SteamWirelessNetworkManager.GLOBAL_STEAM.clear();
-      MapStorage storage = world.field_72988_C;
-      INSTANCE = (GlobalSteamWorldSavedData)storage.func_75742_a(GlobalSteamWorldSavedData.class, "GregTech_WirelessSteamWorldSavedData");
-      if (INSTANCE == null) {
-         INSTANCE = new GlobalSteamWorldSavedData();
-         storage.func_75745_a("GregTech_WirelessSteamWorldSavedData", INSTANCE);
-      }
+    public static GlobalSteamWorldSavedData INSTANCE;
 
-      INSTANCE.func_76185_a();
-   }
+    public static final String DATA_NAME = "GregTech_WirelessSteamWorldSavedData";
 
-   public GlobalSteamWorldSavedData() {
-      super("GregTech_WirelessSteamWorldSavedData");
-   }
+    public static final String GLOBAL_STEAM_NBT_TAG = "GregTech_GlobalSteam_MapNBTTag";
+    public static final String GLOBAL_STEAM_TEAM_NBT_TAG = "GregTech_GlobalSteamTeam_MapNBTTag";
 
-   public GlobalSteamWorldSavedData(String name) {
-      super(name);
-   }
+    public static void loadInstance(World world) {
+        GLOBAL_STEAM.clear();
 
-   public void func_76184_a(NBTTagCompound nbtTagCompound) {
-      byte[] ba;
-      ByteArrayInputStream byteArrayInputStream;
-      ObjectInputStream objectInputStream;
-      Object data;
-      Map oldTeams;
-      Iterator var7;
-      Entry entry;
-      try {
-         ba = nbtTagCompound.func_74770_j("GregTech_GlobalSteam_MapNBTTag");
-         if (ba.length == 0) {
-            return;
-         }
+        MapStorage storage = world.mapStorage;
+        INSTANCE = (GlobalSteamWorldSavedData) storage.loadData(GlobalSteamWorldSavedData.class, DATA_NAME);
+        if (INSTANCE == null) {
+            INSTANCE = new GlobalSteamWorldSavedData();
+            storage.setData(DATA_NAME, INSTANCE);
+        }
+        INSTANCE.markDirty();
+    }
 
-         byteArrayInputStream = new ByteArrayInputStream(ba);
+    public GlobalSteamWorldSavedData() {
+        super(DATA_NAME);
+    }
 
-         try {
-            objectInputStream = new ObjectInputStream(byteArrayInputStream);
+    public GlobalSteamWorldSavedData(String name) {
+        super(name);
+    }
 
-            try {
-               data = objectInputStream.readObject();
-               oldTeams = (Map)data;
-               var7 = oldTeams.entrySet().iterator();
+    @Override
+    @SuppressWarnings("unchecked")
+    public void readFromNBT(NBTTagCompound nbtTagCompound) {
+        try {
+            byte[] ba = nbtTagCompound.getByteArray(GLOBAL_STEAM_NBT_TAG);
+            if (ba.length == 0) return;
 
-               while(var7.hasNext()) {
-                  entry = (Entry)var7.next();
+            try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(ba);
+                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
 
-                  try {
-                     SteamWirelessNetworkManager.GLOBAL_STEAM.put(UUID.fromString(entry.getKey().toString()), (BigInteger)entry.getValue());
-                  } catch (RuntimeException var15) {
-                     ScienceNotLeisure.LOG.warn("[GlobalSteamWorldSavedData] Skipping invalid UUID key in GlobalSteam: {}", new Object[]{entry.getKey()});
-                  }
-               }
-            } catch (Throwable var19) {
-               try {
-                  objectInputStream.close();
-               } catch (Throwable var14) {
-                  var19.addSuppressed(var14);
-               }
+                Object data = objectInputStream.readObject();
+                Map<Object, BigInteger> hashData = (Map<Object, BigInteger>) data;
 
-               throw var19;
+                for (Map.Entry<Object, BigInteger> entry : hashData.entrySet()) {
+                    try {
+                        GLOBAL_STEAM.put(
+                            UUID.fromString(
+                                entry.getKey()
+                                    .toString()),
+                            entry.getValue());
+                    } catch (RuntimeException ignored) {
+                        ScienceNotLeisure.LOG.warn(
+                            "[GlobalSteamWorldSavedData] Skipping invalid UUID key in GlobalSteam: {}",
+                            entry.getKey());
+                    }
+                }
             }
+        } catch (IOException | ClassNotFoundException exception) {
+            ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} LOAD FAILED", GLOBAL_STEAM_NBT_TAG, exception);
+        }
 
-            objectInputStream.close();
-         } catch (Throwable var20) {
-            try {
-               byteArrayInputStream.close();
-            } catch (Throwable var13) {
-               var20.addSuppressed(var13);
+        try {
+            if (!nbtTagCompound.hasKey(GLOBAL_STEAM_TEAM_NBT_TAG)) return;
+
+            byte[] ba = nbtTagCompound.getByteArray(GLOBAL_STEAM_TEAM_NBT_TAG);
+            if (ba.length == 0) return;
+
+            try (ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(ba);
+                ObjectInputStream objectInputStream = new ObjectInputStream(byteArrayInputStream)) {
+
+                Object data = objectInputStream.readObject();
+                Map<String, String> oldTeams = (Map<String, String>) data;
+
+                for (Map.Entry<String, String> entry : oldTeams.entrySet()) {
+                    try {
+                        SpaceProjectManager
+                            .putInTeam(UUID.fromString(entry.getKey()), UUID.fromString(entry.getValue()));
+                    } catch (RuntimeException ignored) {
+                        ScienceNotLeisure.LOG.warn(
+                            "[GlobalSteamWorldSavedData] Skipping invalid UUID in team entry: {}",
+                            entry.getKey());
+                    }
+                }
             }
+        } catch (IOException | ClassNotFoundException exception) {
+            ScienceNotLeisure.LOG
+                .error("[GlobalSteamWorldSavedData] {} LOAD FAILED", GLOBAL_STEAM_TEAM_NBT_TAG, exception);
+        }
+    }
 
-            throw var20;
-         }
+    @Override
+    public void writeToNBT(NBTTagCompound nbtTagCompound) {
+        try (ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream)) {
 
-         byteArrayInputStream.close();
-      } catch (ClassNotFoundException | IOException var21) {
-         ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} LOAD FAILED", new Object[]{"GregTech_GlobalSteam_MapNBTTag", var21});
-      }
+            objectOutputStream.writeObject(GLOBAL_STEAM);
+            objectOutputStream.flush();
 
-      try {
-         if (!nbtTagCompound.func_74764_b("GregTech_GlobalSteamTeam_MapNBTTag")) {
-            return;
-         }
+            nbtTagCompound.setByteArray(GLOBAL_STEAM_NBT_TAG, byteArrayOutputStream.toByteArray());
 
-         ba = nbtTagCompound.func_74770_j("GregTech_GlobalSteamTeam_MapNBTTag");
-         if (ba.length == 0) {
-            return;
-         }
-
-         byteArrayInputStream = new ByteArrayInputStream(ba);
-
-         try {
-            objectInputStream = new ObjectInputStream(byteArrayInputStream);
-
-            try {
-               data = objectInputStream.readObject();
-               oldTeams = (Map)data;
-               var7 = oldTeams.entrySet().iterator();
-
-               while(var7.hasNext()) {
-                  entry = (Entry)var7.next();
-
-                  try {
-                     SpaceProjectManager.putInTeam(UUID.fromString((String)entry.getKey()), UUID.fromString((String)entry.getValue()));
-                  } catch (RuntimeException var12) {
-                     ScienceNotLeisure.LOG.warn("[GlobalSteamWorldSavedData] Skipping invalid UUID in team entry: {}", new Object[]{entry.getKey()});
-                  }
-               }
-            } catch (Throwable var16) {
-               try {
-                  objectInputStream.close();
-               } catch (Throwable var11) {
-                  var16.addSuppressed(var11);
-               }
-
-               throw var16;
-            }
-
-            objectInputStream.close();
-         } catch (Throwable var17) {
-            try {
-               byteArrayInputStream.close();
-            } catch (Throwable var10) {
-               var17.addSuppressed(var10);
-            }
-
-            throw var17;
-         }
-
-         byteArrayInputStream.close();
-      } catch (ClassNotFoundException | IOException var18) {
-         ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} LOAD FAILED", new Object[]{"GregTech_GlobalSteamTeam_MapNBTTag", var18});
-      }
-
-   }
-
-   public void func_76187_b(NBTTagCompound nbtTagCompound) {
-      try {
-         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-         try {
-            ObjectOutputStream objectOutputStream = new ObjectOutputStream(byteArrayOutputStream);
-
-            try {
-               objectOutputStream.writeObject(SteamWirelessNetworkManager.GLOBAL_STEAM);
-               objectOutputStream.flush();
-               nbtTagCompound.func_74773_a("GregTech_GlobalSteam_MapNBTTag", byteArrayOutputStream.toByteArray());
-            } catch (Throwable var8) {
-               try {
-                  objectOutputStream.close();
-               } catch (Throwable var7) {
-                  var8.addSuppressed(var7);
-               }
-
-               throw var8;
-            }
-
-            objectOutputStream.close();
-         } catch (Throwable var9) {
-            try {
-               byteArrayOutputStream.close();
-            } catch (Throwable var6) {
-               var9.addSuppressed(var6);
-            }
-
-            throw var9;
-         }
-
-         byteArrayOutputStream.close();
-      } catch (IOException var10) {
-         ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} SAVE FAILED", new Object[]{"GregTech_GlobalSteam_MapNBTTag", var10});
-      }
-
-   }
+        } catch (IOException exception) {
+            ScienceNotLeisure.LOG.error("[GlobalSteamWorldSavedData] {} SAVE FAILED", GLOBAL_STEAM_NBT_TAG, exception);
+        }
+    }
 }

--- a/src/main/java/com/science/gtnl/utils/world/steam/SteamWirelessNetworkManager.java
+++ b/src/main/java/com/science/gtnl/utils/world/steam/SteamWirelessNetworkManager.java
@@ -1,17 +1,17 @@
 package com.science.gtnl.utils.world.steam;
 
 import java.math.BigInteger;
+import java.util.HashMap;
 import java.util.UUID;
 
 import com.science.gtnl.ScienceNotLeisure;
 
 import gregtech.api.interfaces.tileentity.IGregTechTileEntity;
 import gregtech.common.misc.spaceprojects.SpaceProjectManager;
-import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 
 public class SteamWirelessNetworkManager {
 
-    public static final Object2ObjectOpenHashMap<UUID, BigInteger> GLOBAL_STEAM = new Object2ObjectOpenHashMap<>(
+    public static final HashMap<UUID, BigInteger> GLOBAL_STEAM = new HashMap<>(
         100,
         0.9f);
 


### PR DESCRIPTION
writeToNBT 将 GLOBAL_STEAM 序列化为 Object2ObjectOpenHashMap，
但 readFromNBT 将其强制转型为 HashMap。Object2ObjectOpenHashMap
不继承 HashMap，导致每次加载世界时抛出 ClassCastException，
无线蒸汽网络缓存被清空。

修复方法：将 (HashMap) 转型改为 (Map) 接口转型，并将后续
invokevirtual HashMap.entrySet() 改为 invokeinterface Map.entrySet()

复现方式：
1. 搭建无线蒸汽网络并输入蒸汽
2. 保存退出，重新加载存档 → 蒸汽归零
3. 日志中可见 ClassCastException 堆栈，每个 session 都出现

诊断过程由 Claude (Anthropic) 辅助完成。

游戏日志见附件
[2026-05-30-1.log.gz](https://github.com/user-attachments/files/28907790/2026-05-30-1.log.gz)
[2026-05-31-1.log.gz](https://github.com/user-attachments/files/28907793/2026-05-31-1.log.gz)
[2026-06-01-1.log.gz](https://github.com/user-attachments/files/28907794/2026-06-01-1.log.gz)
