### PR TITLE
修复无尽火把与三重火把的组装机配方冲突

### DIFF
--- a/src/main/java/com/science/gtnl/common/recipe/gregtech/AssemblerRecipes.java
+++ b/src/main/java/com/science/gtnl/common/recipe/gregtech/AssemblerRecipes.java
@@ -1952,7 +1952,7 @@ public class AssemblerRecipes implements IRecipePool {
 
         RecipeBuilder.builder()
             .itemInputs(
-                GTUtility.getIntegratedCircuit(3),
+                GTUtility.getIntegratedCircuit(6),
                 new ItemStack(Blocks.torch, 64),
                 new ItemStack(Blocks.torch, 64),
                 new ItemStack(Blocks.torch, 64),


### PR DESCRIPTION
## Summary

- Change the Infinity Torch assembler selector from integrated circuit 3 to 6.
- Avoid the recipe collision with the existing Triple Torch assembler recipe on the GTNH 2.8 line.

## Root cause

The `dev-28x` Infinity Torch recipe uses the same torch input and integrated circuit 3 as the existing Triple Torch recipe, so the assembler cannot distinguish them reliably.

## User impact

Both torch recipes can be selected independently after this change.

## Validation

- `./gradlew compileJava --no-daemon` with Java 17
- `git diff --check`

Related: #576 (automatically closed because it was submitted without the template-provided label)
